### PR TITLE
Support ESKO zae files with texture files as blubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**In Progress**
+**Alpha to be used with Esko Studio Export to collada**
 
 # zipped-collada-loader-js
 THREE js loader for loading a zipped ZAE Collada file


### PR DESCRIPTION
This commit will replace the texture files in the collada file to point to memory based image blub files found in the .zae archive files. The intention of this commit is to easily view ESKO models online via threejs.